### PR TITLE
Small updates to certificate provisioning

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,18 +1,26 @@
 # ACM certificate resource with the domain name and DNS validation method, supporting subject alternative names
-resource "aws_acm_certificate" "cert" {
-  provider                  = aws.acm_provider
-  domain_name               = var.domain_name
-  validation_method         = "EMAIL"
-  subject_alternative_names = ["*.${var.domain_name}"]
-
+resource "aws_acm_certificate" "certificate" {
+  domain_name = var.domain_name
+  provider    = aws.acm_provider
+  subject_alternative_names = [
+    "www.${var.domain_name}"
+  ]
+  validation_method = "EMAIL"
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
+  tags = {
+    Name = "website-certificate"
+  }
   lifecycle {
     create_before_destroy = true
   }
+
 }
 
 # ACM certificate validation resource using the certificate ARN and a list of validation record FQDNs.
 resource "aws_acm_certificate_validation" "cert" {
   provider        = aws.acm_provider
-  certificate_arn = aws_acm_certificate.cert.arn
+  certificate_arn = aws_acm_certificate.certificate.arn
   # validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -36,7 +36,7 @@ resource "aws_cloudfront_distribution" "cdn_static_website" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate.cert.arn
+    acm_certificate_arn      = aws_acm_certificate.certificate.arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -7,9 +7,8 @@ data "aws_route53_zone" "zone" {
 
 # AWS Route53 record resource for certificate validation with dynamic for_each loop and properties for name, records, type, zone_id, and ttl.
 resource "aws_route53_record" "cert_validation" {
-  provider = aws.use_default_region
   for_each = {
-    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+    for dvo in aws_acm_certificate.certificate.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
@@ -19,9 +18,9 @@ resource "aws_route53_record" "cert_validation" {
   allow_overwrite = true
   name            = each.value.name
   records         = [each.value.record]
+  ttl             = 30
   type            = each.value.type
   zone_id         = data.aws_route53_zone.zone.zone_id
-  ttl             = 60
 }
 
 # AWS Route53 record resource for the "www" subdomain. The record uses an "A" type record and an alias to the AWS CloudFront distribution with the specified domain name and hosted zone ID. The target health evaluation is set to false.


### PR DESCRIPTION
The certificate should use the fully qualified domain, and this adds future functionality to validate using DNS.